### PR TITLE
Replace Discord blog url with the new one

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ It's a pretty simple one and emanates from the paragraph above. Since Chromium c
 As mentioned in the prologue there are still some issues to be resolved.
 1. Screenshare is only 720p 30fps. This cannot be fixed by forcing frameRate, width and height Video constraints.
 2. Audio of both the microphone and desktop streams is mono. Forcing the channelCount: 2 constraint solely doesn't fix it. While Chromium recognizes it as stereo, Discord downmixes it.
-3. This doesn't work on the Discord electron client. Electron uses getUserMedia to share your screen instead of getDisplayMedia, yet the official Discord client doesn't do any of these. As noted [here](https://blog.discord.com/how-discord-handles-two-and-half-million-concurrent-voice-users-using-webrtc-ce01c3187429), Discord uses a native module called MediaEngine that takes care of all input and output for their desktop and mobile clients which makes it difficult to do anything without a foss drop-in replacement.
+3. This doesn't work on the Discord electron client. Electron uses getUserMedia to share your screen instead of getDisplayMedia, yet the official Discord client doesn't do any of these. As noted [here](https://discord.com/blog/how-discord-handles-two-and-half-million-concurrent-voice-users-using-webrtc), Discord uses a native module called MediaEngine that takes care of all input and output for their desktop and mobile clients which makes it difficult to do anything without a foss drop-in replacement.
 4. This method is also problematic on Firefox, see below.
 
 ## The script


### PR DESCRIPTION
Was just looking at this repo and clicked on the blog link. 
I was wondering why I only got an empty page and figured out that Discord now uses a new url for their blog.

Since this a really tiny fix (and I contribute no real value here), you could just commit that change yourself and close this PR. :D